### PR TITLE
Update start cards 156849921 156849905

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -19,7 +19,7 @@ class Game < ApplicationRecord
         player = Player.find(player_id)
         new_game.players << player
       end
-      new_game.game_cards << GameCard.new_game
+      new_game.game_cards << GameCard.new_game(players)
     end
     new_game
   end

--- a/app/models/game_card.rb
+++ b/app/models/game_card.rb
@@ -2,22 +2,15 @@ class GameCard < ApplicationRecord
   belongs_to :game
   belongs_to :card
 
-  def self.new_game
+  def self.new_game(players)
     game_cards = [
-      #copper
-      GameCard.new(card_id: Card.find_by(name: 'copper').id, quantity: 40),
-      #curse
-      GameCard.new(card_id: Card.find_by(name: 'curse').id, quantity: 10),
-      #silver
-      GameCard.new(card_id: Card.find_by(name: 'silver').id, quantity: 30),
-      #gold
+      GameCard.new(card_id: Card.find_by(name: 'copper').id, quantity: (60 - players.count * 7)),
+      GameCard.new(card_id: Card.find_by(name: 'curse').id, quantity: ((players.count - 1) * 10)),
+      GameCard.new(card_id: Card.find_by(name: 'silver').id, quantity: 40),
       GameCard.new(card_id: Card.find_by(name: 'gold').id, quantity: 30),
-      #estate
-      GameCard.new(card_id: Card.find_by(name: 'estate').id, quantity: 10),
-      #duchy
-      GameCard.new(card_id: Card.find_by(name: 'duchy').id, quantity: 10),
-      #provice
-      GameCard.new(card_id: Card.find_by(name: 'province').id, quantity: 10)
+      GameCard.new(card_id: Card.find_by(name: 'estate').id, quantity: victory_cards(players.count)),
+      GameCard.new(card_id: Card.find_by(name: 'duchy').id, quantity: victory_cards(players.count)),
+      GameCard.new(card_id: Card.find_by(name: 'province').id, quantity: victory_cards(players.count))
     ]
     kingdom_cards = Card.kingdom.where(set: :dominion).sample(10)
     kingdom_cards.each do |kingdom_card|
@@ -25,4 +18,9 @@ class GameCard < ApplicationRecord
     end
     game_cards
   end
+end
+
+def victory_cards(player_count)
+  return 12 if player_count > 2
+  return 8
 end

--- a/lib/tasks/import_cards_built.rake
+++ b/lib/tasks/import_cards_built.rake
@@ -1,0 +1,9 @@
+require 'csv'
+
+task import_cards_built: :environment do
+  CSV.foreach('./public/cards_built_2018-04-07.csv', headers: true, header_converters: :symbol) do |row|
+    row[:attack] = 0 if row[:attack] == nil
+    puts "#{row[:name]} Added"
+    Card.create(name: row[:name], cost: row[:cost], attack: row[:attack], set: row[:expansion].downcase)
+  end
+end

--- a/public/cards_built_2018-04-07.csv
+++ b/public/cards_built_2018-04-07.csv
@@ -1,0 +1,20 @@
+Name,Expansion,Action,Attack,Curse,Duration,Reaction,Treasure,Victory,Cost,Pot,Action,Buy,Card,Coin,VP,Text
+Chapel,Dominion,1,,,,,,,2,,,,,,,Trash up to 4 cards from your hand.
+Moat,Dominion,1,,,,1,,,2,,,,2,,,"When another player plays an Attack card, you may reveal this from your hand. If you do, you are unaffected by that Attack."
+Harbinger,Dominion,1,,,,,,,3,,,,,,,
+Vassal,Dominion,1,,,,,,,3,,,,,,,
+Village,Dominion,1,,,,,,,3,,2,,1,,,
+Moneylender,Dominion,1,,,,,,,4,,,,,,,"Trash a Copper card from your hand. If you do, +3 Coins."
+Smithy,Dominion,1,,,,,,,4,,,,3,,,
+Council Room,Dominion,1,,,,,,,5,,,1,4,,,Each other player draws a card.
+Festival,Dominion,1,,,,,,,5,,2,1,,2,,
+Laboratory,Dominion,1,,,,,,,5,,1,,2,,,
+Market,Dominion,1,,,,,,,5,,1,1,1,1,,
+Witch,Dominion,1,1,,,,,,5,,,,2,,,Each other player gains a Curse card.
+Copper,Dominion,,,,,,1,,0,,,,,1,,
+Silver,Dominion,,,,,,1,,3,,,,,2,,
+Gold,Dominion,,,,,,1,,6,,,,,3,,
+Curse,Dominion,,,1,,,,,0,,,,,,-1,
+Estate,Dominion,,,,,,,1,2,,,,,,1,
+Duchy,Dominion,,,,,,,1,5,,,,,,3,
+Province,Dominion,,,,,,,1,8,,,,,,6,

--- a/spec/models/game_card_spec.rb
+++ b/spec/models/game_card_spec.rb
@@ -1,5 +1,83 @@
 require 'rails_helper'
+require 'rake'
 
-RSpec.describe GameCard, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe GameCard do
+  before(:all) do
+		load File.expand_path("../../../lib/tasks/import_cards_built.rake", __FILE__)
+		Rake::Task.define_task(:environment)
+		Rake::Task['import_cards_built'].invoke
+	end
+
+	after(:all) do
+		DatabaseCleaner.clean
+	end
+
+  context "class methods" do
+    it ".new_game with 2 players" do
+      game_1 = GameCard.new_game([1,2])
+
+      expect(game_1.count).to eq(17)
+      expect(game_1[0].quantity).to eq(46)
+      expect(game_1[1].quantity).to eq(10)
+      expect(game_1[2].quantity).to eq(40)
+      expect(game_1[3].quantity).to eq(30)
+      expect(game_1[4].quantity).to eq(8)
+      expect(game_1[5].quantity).to eq(8)
+      expect(game_1[6].quantity).to eq(8)
+      expect(game_1[7].quantity).to eq(10)
+      expect(game_1[8].quantity).to eq(10)
+      expect(game_1[9].quantity).to eq(10)
+      expect(game_1[10].quantity).to eq(10)
+      expect(game_1[11].quantity).to eq(10)
+      expect(game_1[12].quantity).to eq(10)
+      expect(game_1[13].quantity).to eq(10)
+      expect(game_1[14].quantity).to eq(10)
+      expect(game_1[15].quantity).to eq(10)
+      expect(game_1[16].quantity).to eq(10)
+    end
+    it ".new_game with 3 players" do
+      game_1 = GameCard.new_game([1,2,3])
+
+      expect(game_1.count).to eq(17)
+      expect(game_1[0].quantity).to eq(39)
+      expect(game_1[1].quantity).to eq(20)
+      expect(game_1[2].quantity).to eq(40)
+      expect(game_1[3].quantity).to eq(30)
+      expect(game_1[4].quantity).to eq(12)
+      expect(game_1[5].quantity).to eq(12)
+      expect(game_1[6].quantity).to eq(12)
+      expect(game_1[7].quantity).to eq(10)
+      expect(game_1[8].quantity).to eq(10)
+      expect(game_1[9].quantity).to eq(10)
+      expect(game_1[10].quantity).to eq(10)
+      expect(game_1[11].quantity).to eq(10)
+      expect(game_1[12].quantity).to eq(10)
+      expect(game_1[13].quantity).to eq(10)
+      expect(game_1[14].quantity).to eq(10)
+      expect(game_1[15].quantity).to eq(10)
+      expect(game_1[16].quantity).to eq(10)
+    end
+    it ".new_game with 4 players" do
+      game_1 = GameCard.new_game([1,2,3,4])
+
+      expect(game_1.count).to eq(17)
+      expect(game_1[0].quantity).to eq(32)
+      expect(game_1[1].quantity).to eq(30)
+      expect(game_1[2].quantity).to eq(40)
+      expect(game_1[3].quantity).to eq(30)
+      expect(game_1[4].quantity).to eq(12)
+      expect(game_1[5].quantity).to eq(12)
+      expect(game_1[6].quantity).to eq(12)
+      expect(game_1[7].quantity).to eq(10)
+      expect(game_1[8].quantity).to eq(10)
+      expect(game_1[9].quantity).to eq(10)
+      expect(game_1[10].quantity).to eq(10)
+      expect(game_1[11].quantity).to eq(10)
+      expect(game_1[12].quantity).to eq(10)
+      expect(game_1[13].quantity).to eq(10)
+      expect(game_1[14].quantity).to eq(10)
+      expect(game_1[15].quantity).to eq(10)
+      expect(game_1[16].quantity).to eq(10)
+    end
+  end
 end


### PR DESCRIPTION
This PR creates a new rake task that allows us to import only those cards that we have built logic for on the front end. Additionally, it adds logic to the GameCard model to determine the amount of each cards supply based on the number of players.